### PR TITLE
PR to fix Issue #72

### DIFF
--- a/Part2.R
+++ b/Part2.R
@@ -158,6 +158,9 @@ example_list[[1]]
 
 ## A modern approach to interacting with data frames is called dplyr. This package is part of the tidyverse, a suite of packages that helps facilitate data science in R.
 ## We need to first install this package. We can do so by running the install.packages() function:
+install.packages("dplyr")
+
+## It's good practice to pass the names of packages as a vector of names, and a requirement if you want to install more than one package at a time. The reason for this is that the second argument in install.packages() is the place on your computer where you want to install packages. R is smart enough to know what you mean by default if you just pass a single argument, but install.packages("dplyr", "anotherPackage") will lead to a cryptic warning that "lib = "anotherPackage" is not writable. Wrapping our packages in c() avoids this problem. 
 install.packages(c("dplyr"))
 
 ## Now that it's installed, we need to import it to our current R session:

--- a/Part2.R
+++ b/Part2.R
@@ -158,7 +158,7 @@ example_list[[1]]
 
 ## A modern approach to interacting with data frames is called dplyr. This package is part of the tidyverse, a suite of packages that helps facilitate data science in R.
 ## We need to first install this package. We can do so by running the install.packages() function:
-install.packages(dplyr)
+install.packages(c("dplyr"))
 
 ## Now that it's installed, we need to import it to our current R session:
 library(dplyr)
@@ -214,7 +214,7 @@ head(sleep_NonD)
 ## How can we check whether the new data frame does in fact have no missing values for NonD?
 
 ## Maybe we'd like to extract the *rows* that have no missing values (rather than a specific column). Another package in the tidyverse - tidyr - provides us a useful function to do this:
-install.packages(tidyr)
+install.packages(c("tidyr"))
 library(tidyr)
 
 ## tidyr typically contains functions which allow you to transform your data frames from longer to wider (this is called pivoting). It also contains the drop_na() function, which is useful in this case:

--- a/Part3.R
+++ b/Part3.R
@@ -146,7 +146,7 @@ legend("topleft",
 ## We're now going to create visualizations with the package ggplot2, which is the main way R practitioners create plots. ggplot2 exists as its own package, which we need to download and install. 
 
 ## In the previous lesson, we learned how to install new packages. Now, we'll do the same with ggplot2. First, we install the package:
-install.packages("ggplot2")
+install.packages(c("ggplot2"))
 
 ## Second, we load the installed package in the current session. Remember, you need to do this each time you open a new RStudio session.
 library(ggplot2)


### PR DESCRIPTION
This PR fixes the typos identified in #72 

- Fixes and standardizes the typo in the install packages for tidyr in Part2.R a
- tandardizes the install.packages() code in Part3.R
- Using c() begins good practice because beginners often have difficulty when they have to install multiple packages at once as `install.packages("package")" does not work when generalized `install.packages("package", "package2")` will return a cryptic error to beginners. 

Closes #72.